### PR TITLE
feat: Improve authentication with Google OAuth and Magic Link redirec…

### DIFF
--- a/api/supabase_auth.py
+++ b/api/supabase_auth.py
@@ -289,7 +289,7 @@ def send_magic_link():
         response = supabase.auth.sign_in_with_otp({
             'email': email,
             'options': {
-                'redirect_to': f"{os.getenv('BASE_URL', 'http://localhost:8080')}/auth/callback"
+                'redirect_to': os.getenv('SUPABASE_REDIRECT_URL', 'https://news-copilot.vercel.app/auth/callback')
             }
         })
         

--- a/extension/js/supabase-auth.js
+++ b/extension/js/supabase-auth.js
@@ -41,6 +41,36 @@ class SupabaseAuth {
             });
         }
     }
+
+    async signInWithGoogle() {
+        if (!this.supabase) throw new Error('Supabase not initialized');
+
+        try {
+            const { data, error } = await this.supabase.auth.signInWithOAuth({
+                provider: 'google',
+                options: {
+                    redirectTo: 'https://news-copilot.vercel.app/auth/callback'
+                }
+            });
+
+            if (error) throw error;
+
+            // signInWithOAuth typically redirects, so this part might not be reached
+            // if the redirect happens immediately.
+            // However, if it returns data (e.g., the URL to redirect to),
+            // the caller (popup-supabase.js) will handle the redirect.
+            return {
+                success: true,
+                data: data // This might contain the provider's URL
+            };
+        } catch (error) {
+            console.error('Error signing in with Google:', error);
+            return {
+                success: false,
+                error: error.message
+            };
+        }
+    }
     
     async getConfig() {
         // In production, these should come from your backend or be hardcoded
@@ -74,7 +104,7 @@ class SupabaseAuth {
             const { data, error } = await this.supabase.auth.signInWithOtp({
                 email: email,
                 options: {
-                    emailRedirectTo: `${window.location.origin}/auth/callback`
+                    emailRedirectTo: 'https://news-copilot.vercel.app/auth/callback'
                 }
             });
             
@@ -135,7 +165,7 @@ class SupabaseAuth {
                 result = await this.supabase.auth.signInWithOtp({
                     email: email,
                     options: {
-                        emailRedirectTo: `${window.location.origin}/auth/callback`
+                        emailRedirectTo: 'https://news-copilot.vercel.app/auth/callback'
                     }
                 });
             }

--- a/extension/popup-supabase.html
+++ b/extension/popup-supabase.html
@@ -228,6 +228,7 @@
                 </p>
                 <input type="email" id="emailInput" class="email-input" placeholder="your@email.com">
                 <button id="magicLinkButton" class="auth-button">Αποστολή Magic Link</button>
+                <button id="googleSignInButton" class="auth-button" style="background-color: #DB4437; margin-top: 8px;">Σύνδεση με Google</button>
                 <div id="authMessage" class="hidden"></div>
             </div>
             


### PR DESCRIPTION
…t fix

This commit introduces Google OAuth as a new login method and fixes the magic link redirect issue.

Changes include:
- Modified the magic link `emailRedirectTo` URL in both the frontend extension and backend API to use a consistent production callback URL (`https://news-copilot.vercel.app/auth/callback`). This resolves the issue where magic links would redirect to localhost or an invalid extension URL.
- Added a "Sign in with Google" button to the extension popup.
- Implemented the Google OAuth flow using `supabase.auth.signInWithOAuth`. The OAuth flow also uses the same production callback URL.
- Updated the `SimpleSupabaseClient` in the extension to support the `signInWithOAuth` method by opening the Google authorization URL in a new tab.